### PR TITLE
For to enable build on Fedora 33

### DIFF
--- a/git-remote-qubes.spec
+++ b/git-remote-qubes.spec
@@ -1,3 +1,4 @@
+%define __python /usr/bin/python2
 %define debug_package %{nil}
 
 %define mybuildnumber %{?build_number}%{?!build_number:1}


### PR DESCRIPTION
There is no unversioned python in Fedora 33, python2 or python3 must be explicitly specified.